### PR TITLE
Update readme with doc url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DISCnet_workshop
 DISCnet workshop repository
 
-The full workshop notes are hosted on this repositories GitHub Pages.
+The full workshop notes are hosted on this repositories GitHub Pages URL: https://ckrawczyk.github.io/DISCnet_workshop/
 
 You can also find them in the `docs/source` directory:
 


### PR DESCRIPTION
The GitHub Pages URL is set to https://ckrawczyk.github.io/DISCnet_workshop/ in the readme.