### PR TITLE
Add notes about package versions

### DIFF
--- a/data_transforms/__init__.py
+++ b/data_transforms/__init__.py
@@ -4,3 +4,5 @@ format and flattens it into un-nested structures ready for analysis.
 '''
 
 from .angle_metric import angle_distance  # noqa: F401
+
+__version__ = '0.1.0'

--- a/docs/source/good_coding_practices.md
+++ b/docs/source/good_coding_practices.md
@@ -45,24 +45,24 @@ It is difficult to review code if you don't know what task the code it trying to
 - Keep in mind your reviewer will be mostly looking at code diffs, so put some thought how you changes will look in that format.  As and example take the following code change:
 
 ```python
-a = [1, 2, 3, 4, 5, 6]
+a = {'b': 2, 'c': 3, 'd': {'e': 5, 'f': 6}}
 ```
 changes to 
 ```python
-a = [1, 3, 3, 4, 6, 6]
+a = {'b': 1, 'c': 3, 'd': {'e': 5, 'f': 7}}
 ```
 
-There are two changes made to elements of the list, as written these will show up as one line of code changed.  If the line is quite long (or the reviewer is only looking at the code quickly) they might only see the first change.  To make it more obvious that multiple elements change you can format the code as:
+There are two changes made to elements of the dictionary, as written these will show up as one line of code changed.  If the line is quite long (or the reviewer is only looking at the code quickly) they might only see the first change.  To make it more obvious that multiple elements change you can format the code so every element is on its own line:
 
 ```python
-a = [
-    1,
-    2,
-    3,
-    4,
-    5,
-    6
-]
+a = {
+    'b': 1,
+    'c': 3,
+    'd': {
+        'e': 5, 
+        'f': 7
+    }
+}
 ```
 
 That way each element change is shown as a different line in the code diff.  As an added bonus this can help shorten long lines of code.
@@ -86,9 +86,41 @@ DISCnet_workshop (git repository)
 ```
 
 Let's dive into a few of these things in more detail
-- `__init__.py`: A python package treats every folder as a class with this file as the initialization function, useful for pulling functions from the files and folders inside this folder into the top level namespace.
+- `__init__.py`: A python package treats every folder as a class with this file as the initialization function, useful for pulling functions from the files and folders inside this folder into the top level namespace.  The top level `__init__.py` typically also stores the package `__version__` variable.
 - `LICENSE`: You should choose a license for your code. [Choose A License](https://choosealicense.com/) is a good resource for figuring out what license is best for your project.  The typical ones seen for research code are the [MIT license](https://choosealicense.com/licenses/mit/) and [Apache 2.0 license](https://choosealicense.com/licenses/apache-2.0/).
 - `setup.cfg`: This file tells python how to install your code, what dependencies to install, and various development configuration options.
+
+### Setting dependency versions
+
+To help with code reproducibility and dependency compatibility you can should pin dependency versions to a single value or a range.  It is python convention that the dependencies in `setup.cfg` are pinned as **ranges** to ensure they are easy to install into existing environments and not collide with the dependencies of other packages installed.  An optional `requirements.txt` file is typically used to pin down **exact** package versions when reproducibility is more important (e.g. all developers wanting to have the same versions installed or keeping a record of the package versions installed when a paper was published using the code).
+
+```note
+Most python packages use [semantic versioning](https://semver.org/).  This means the version numbers are set as MAJOR.MINOR.PATCH 
+- MAJOR version increments when incompatible API changes are made to the code
+- MINOR version increments when a new feature is added in a backward compatible manner
+- PATCH version increments when a backward compatible bug fix is made
+```
+
+The rule of thumb I use when pinning down my packages ranges in `setup.cfg`:
+- Set the lower bound as `>=` the exact version currently installed in my environment (use `conda list` or `pip freeze` to view the current versions of installed packages)
+- Set the upper bound as `<` the next patch fix version of the package
+- Activate [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) on GitHub to automatically make pull requests that update the upper bound when dependencies update (as we will see in the next section this will trigger our tests to run automatically and let us know if the update breaks the code)
+    - If a dependency update breaks the code (typically major version updates), update the code and set the lower bound to be the latest version of the dependency
+
+### Versioning your package
+
+It is a good idea to use single-source package versioning, this means the package version is defined in exactly one place inside the repository.  For python this is typically inside the top level `__init__.py` file and stored with the variable name `__version__`.  The `setup.cfg` file can read this version by using:
+
+```
+[metadata]
+version = attr: data_transforms.__version__
+```
+
+where `data_transforms` is the name of the python package we are writing in this workshop.
+
+When you are ready to release a new version of your code make a new PR that only bumps the version number using semantic versioning (see note above).  Once merged add a git tag to the merge commit.  You can also add additional notes about the release when making the tag, this a good place to include what things have changed in the new release.
+
+For larger projects it is worth keeping a separate `CHANGELOG.md` file inside the repository or a changelog section in the `README.md` that tracks all the changes introduced in each version bump to make this information easier to find.  There are tools available to help automate this process, these typically involve using special keywords when writing git commit messages to flag up text related to new features and/or breaking changes (e.g. [auto-changelog](https://github.com/KeNaCo/auto-changelog)).
 
 ## Text editors
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = data_transforms
-version = 0.1.0
+version = attr: data_transforms.__version__
 author = DISCnet
 description = DISCnet workshop code
 long_description = DISCnet workshop code covering good coding practices, GitHub usage, and test-dirven-development
@@ -9,20 +9,20 @@ url = https://github.com/CKrawczyk/DISCnet_workshop
 [options]
 package_dir =
     = data_transforms
-python_requires = >=3.9
+python_requires = >= 3.10
 setup_requires =
-    setuptools
+    setuptools >= 61.2.0
 install_requires =
-    numpy
-    pandas
+    numpy >= 1.22.3, < 1.22.4
+    pandas >= 1.4.2, < 1.4.3
 
 [options.extras_require]
 dev = 
-    coverage
-    flake8
-    myst-nb
-    sphinx
-    sphinx_rtd_theme
+    coverage >= 6.3.2, < 6.3.3
+    flake8 >= 4.0.1, < 4.0.2
+    myst-nb >= 0.15.0, < 0.15.1
+    sphinx >= 4.5.0, < 4.5.1
+    sphinx_rtd_theme >= 1.0.0, < 1.0.1
 
 [flake8]
 exclude =


### PR DESCRIPTION
New notes about pinning dependency versions and setting your package's version.

Also, update the code to use single-source versioning (this is so much easier to do now with `setup.cfg`!)