### PR TITLE
Updte packaging notes

### DIFF
--- a/docs/source/code_structure.md
+++ b/docs/source/code_structure.md
@@ -1,0 +1,51 @@
+# Code and file structure
+
+One of the key things to keep in mind when writing code in a team is that other people will be reading and reviewing you code.  To that end it is always worth the time make the process of reading your code as easy as possible.
+
+## Organizing your code
+
+Step one in making your code more readable is to organize it into different files and folders.  Some rules that help with this:
+
+- Every file has one large function, one class, or collection of related small functions
+    - The file name should reflect what the code in the file does
+- Group the files by the general task they complete (e.g. a folder of plotting code and a folder for analysis)
+    - The folder name should reflect this general task
+
+It is OK if you don't have a full plan for what these file and folder structures will look like before you start, you can always re-organize your code after it is written.  The important thing is to have it be at least somewhat organized before code review.  Any question you have about this structure you can alway flag up for your reviewer to take a look at and help answer.
+
+## Code legibility
+
+It is difficult to review code if you don't know what task the code it trying to solve.  Aside from supplying the context for your code in your PR message and/or commit message (more on that later), there are thing you can do directly in your code to help your reviewer:
+
+- Use descriptive variable names
+- Write documentation strings explaining every input and output
+- Write your code in the simplest way that works
+    - It should be obvious from the code written what is being done
+- If you need to do something in a "clever" way write a comment about it and record in a comment, commit message, and/or PR message why this is needed
+- Make sure the tone of your comments matches who you expect to be reading them
+    - Comments targeted at people learning python syntax for the first time should look different than comments targeted at people who have been using python for several years
+- Stick to a consistent coding style (more on this latter)
+- Keep in mind your reviewer will be mostly looking at code diffs, so put some thought how you changes will look in that format.  As and example take the following code change:
+
+```python
+a = {'b': 2, 'c': 3, 'd': {'e': 5, 'f': 6}}
+```
+changes to 
+```python
+a = {'b': 1, 'c': 3, 'd': {'e': 5, 'f': 7}}
+```
+
+There are two changes made to elements of the dictionary, as written these will show up as one line of code changed.  If the line is quite long (or the reviewer is only looking at the code quickly) they might only see the first change.  To make it more obvious that multiple elements change you can format the code so every element is on its own line:
+
+```python
+a = {
+    'b': 1,
+    'c': 3,
+    'd': {
+        'e': 5, 
+        'f': 7
+    }
+}
+```
+
+That way each element change is shown as a different line in the code diff.  As an added bonus this can help shorten long lines of code.

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -1,4 +1,4 @@
-# Getting Started
+# Getting started
 
 ## Making a clean python environment
 
@@ -58,7 +58,7 @@ cd DISCnet_workshop
 Throughout this workshop you will be helping to write a python package called `data_transforms`.  To install it into your new environment (once the env is activated) run:
 
 ```bash
-pip install -U pip
+pip install -U pip flit
 pip install -e .[dev]
 ```
 

--- a/docs/source/good_coding_practices.md
+++ b/docs/source/good_coding_practices.md
@@ -60,7 +60,7 @@ To set up VScode to use `flake8` open the settings and search for `python lintin
 
 While `flake8` is a great starting point, it is just that, a starting point.  PEP 8 should be used as a guideline for your projects style and if there are any rules you don't agree with you are free to turn them off.  While this can be configured globally on your local computer, I would recommend doing at the project level inside your code's `setup.cfg` file.  By doing it at the project level your choice of style rules will be saved **inside the project** for all developers to see.  That way everyone contributing code to the project knows what rules to follow (and what ones can be ignored).
 
-In particular, withing `flake8` rules [W503](https://www.flake8rules.com/rules/W503.html) and [W504](https://www.flake8rules.com/rules/W504.html) are the exact opposite of each other, so one of them must be ignored.  Within this project I have already set up the `flake8` configuration in the `setup.cfg` file to:
+In particular, withing `flake8` rules [W503](https://www.flake8rules.com/rules/W503.html) and [W504](https://www.flake8rules.com/rules/W504.html) are the exact opposite of each other, so one of them must be ignored.  Within this project I have already set up the `flake8` configuration in the `.flake8` file to:
 
 - ignore the project configuration folders (.git, docs, etc...)
 - Set the max line length to 120

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ DISCnet Workshop: Writing Code as a Team
    getting_started
    good_coding_practices
    github_with_collaborators
+   code_structure
    packaging_python_code
    writing_documentation
    test_driven_development

--- a/docs/source/packaging_python_code.md
+++ b/docs/source/packaging_python_code.md
@@ -1,60 +1,34 @@
 # Packaging Python code
 
-## Code and file structure
+This section of notes are adapted from [https://github.com/cameron-simpson/css/blob/pypi/doc/pypa-the-missing-outline.md](https://github.com/cameron-simpson/css/blob/pypi/doc/pypa-the-missing-outline.md)
 
-One of the key things to keep in mind when writing code in a team is that other people will be reading and reviewing you code.  To that end it is always worth the time make the process of reading your code as easy as possible.
+A python package is the process of collecting your code in a way that can be installed on a different person's computer and work in the same way it did on yours.  This process is made up of several parts:
 
-### Organizing your code
+- The source code
+- A configuration file with the package's metadata (a `pyproject.toml` file)
+- Build artifacts that are uploaded to a package distribution service such as [PyPI](https://pypi.org/).  These are typically a source distribution (sdist) and a built distribution (wheel).
 
-Step one in making your code more readable is to organize it into different files and folders.  Some rules that help with this:
+## The build system
 
-- Every file has one large function, one class, or collection of related small functions
-    - The file name should reflect what the code in the file does
-- Group the files by the general task they complete (e.g. a folder of plotting code and a folder for analysis)
-    - The folder name should reflect this general task
+To build your package you will need to pick a build system.  There are no build systems that come with python by default.  In the past `setuptools` was the defacto standard, but in recent years more have become available.  For this workshop we will be using [flit](https://flit.pypa.io/en/latest/) as it is lightweight and compliant with the latest python standards.
 
-It is OK if you don't have a full plan for what these file and folder structures will look like before you start, you can always re-organize your code after it is written.  The important thing is to have it be at least somewhat organized before code review.  Any question you have about this structure you can alway flag up for your reviewer to take a look at and help answer.
+A build system typically comes with a command line interface (CLI) that can automate common tasks such as making a new python environment with you code, bumping your code's version number, building the `sdist` and `wheel`s, or uploading the builds to PyPI.
 
-### Code legibility
+Common build systems are:
+- [flit](https://flit.pypa.io/en/latest/): just a build system, nothing more
+- [hatch](https://hatch.pypa.io/latest/): build system and environment management
+- [pdm](https://pdm.fming.dev/latest/): build system, dependency management, dependency locking, and environment management (note: the environments are handled in the background so you don't have to do it by hand)
+- [poetry](https://python-poetry.org/docs): build system, dependency management, dependency locking, and environment management (note: not PEP 621 compliant, but it is on their long-term [feature road map](https://github.com/python-poetry/roadmap/issues/3))
 
-It is difficult to review code if you don't know what task the code it trying to solve.  Aside from supplying the context for your code in your PR message and/or commit message (more on that later), there are thing you can do directly in your code to help your reviewer:
+Each of these build systems have different workflows when managing your python package, it can be useful to try some of them out and see what one fits your project best.
 
-- Use descriptive variable names
-- Write documentation strings explaining every input and output
-- Write your code in the simplest way that works
-    - It should be obvious from the code written what is being done
-- If you need to do something in a "clever" way write a comment about it and record in a comment, commit message, and/or PR message why this is needed
-- Make sure the tone of your comments matches who you expect to be reading them
-    - Comments targeted at people learning python syntax for the first time should look different than comments targeted at people who have been using python for several years
-- Stick to a consistent coding style (more on this latter)
-- Keep in mind your reviewer will be mostly looking at code diffs, so put some thought how you changes will look in that format.  As and example take the following code change:
-
-```python
-a = {'b': 2, 'c': 3, 'd': {'e': 5, 'f': 6}}
-```
-changes to 
-```python
-a = {'b': 1, 'c': 3, 'd': {'e': 5, 'f': 7}}
+```{note}
+Python's packaging landscape is currently (Summer 2022) in flux.  You will find many out of date tutorials around making a `setup.py` and/or `setup.cfg` instead of/in addition to the `pyproject.toml`.  As of [PEP 621](https://peps.python.org/pep-0621/) that was approved in 2021, the method outlined in these notes is the "approved python" way of making a package going forward.  As of `pip` version 22.1.2 this new way of packaging is fully supported. 
 ```
 
-There are two changes made to elements of the dictionary, as written these will show up as one line of code changed.  If the line is quite long (or the reviewer is only looking at the code quickly) they might only see the first change.  To make it more obvious that multiple elements change you can format the code so every element is on its own line:
+## The source code structure
 
-```python
-a = {
-    'b': 1,
-    'c': 3,
-    'd': {
-        'e': 5, 
-        'f': 7
-    }
-}
-```
-
-That way each element change is shown as a different line in the code diff.  As an added bonus this can help shorten long lines of code.
-
-## The package structure
-
-Packaging your code will make it easier for others (including yourself) to install and use your code.  In this section I will go over how to package python code.  This workshop's repository is already setup to be a python package and can be used as a reference:
+This workshop's repository is already setup to be a python package let's take a closer look at the structure.  The minimum files for this workshop's code are:
 
 ```
 DISCnet_workshop (git repository)
@@ -66,18 +40,16 @@ DISCnet_workshop (git repository)
 │       └── test_angle_metric.py (test file)
 ├── LICENSE (make sure you license your code)
 ├── README.md (shown on the github page)
-├── setup.cfg (python package configuration)
-└── setup.py (needed for back compatibility for older versions of pip)
+└── pyproject.toml (contains package metadata and dependencies)
 ```
 
-Let's dive into a few of these things in more detail
 - `__init__.py`: A python package treats every folder as a class with this file as the initialization function, useful for pulling functions from the files and folders inside this folder into the top level namespace.  The top level `__init__.py` typically also stores the package `__version__` variable.
 - `LICENSE`: You should choose a license for your code. [Choose A License](https://choosealicense.com/) is a good resource for figuring out what license is best for your project.  The typical ones seen for research code are the [MIT license](https://choosealicense.com/licenses/mit/) and [Apache 2.0 license](https://choosealicense.com/licenses/apache-2.0/).
-- `setup.cfg`: This file tells python how to install your code, what dependencies to install, and various development configuration options.
+- `pyproject.toml`: This file tells python how to install your code, what dependencies to install, and various development configuration options.  You can use `flit init` to help build this file or just write it by hand.
 
-### Setting dependency versions
+## Setting dependency versions
 
-To help with code reproducibility and dependency compatibility you can should pin dependency versions to a single value or a range.  It is python convention that the dependencies in `setup.cfg` are pinned as **ranges** to ensure they are easy to install into existing environments and not collide with the dependencies of other packages installed.  An optional `requirements.txt` file is typically used to pin down **exact** package versions when reproducibility is more important (e.g. all developers wanting to have the same versions installed or keeping a record of the package versions installed when a paper was published using the code).
+To help with code reproducibility and dependency compatibility you can should pin dependency versions to a single value or a range.  It is python convention that the dependencies in `pyproject.toml` are pinned as **ranges** to ensure they are easy to install into existing environments and not collide with the dependencies of other packages installed.  An optional file (either `requirements.txt` or the lock file created by your build tool) is used to pin down **exact** package versions when reproducibility is important (e.g. all developers wanting to have the same versions of all dependencies installed or keeping a record of the package versions installed when a paper was published using the code).
 
 ```{note}
 Most python packages use [semantic versioning](https://semver.org/).  This means the version numbers are set as MAJOR.MINOR.PATCH 
@@ -92,17 +64,47 @@ The rule of thumb I use when pinning down my packages ranges in `setup.cfg`:
 - Activate [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) on GitHub to automatically make pull requests that update the upper bound when dependencies update (as we will see in the next section this will trigger our tests to run automatically and let us know if the update breaks the code)
     - If a dependency update breaks the code (typically major version updates), update the code and set the lower bound to be the latest version of the dependency
 
-### Versioning your package
-
-It is a good idea to use single-source package versioning, this means the package version is defined in exactly one place inside the repository.  For python this is typically inside the top level `__init__.py` file and stored with the variable name `__version__`.  The `setup.cfg` file can read this version by using:
-
-```
-[metadata]
-version = attr: data_transforms.__version__
+```{warning}
+Related to the current changing landscape of Python packaging the current packaging method is [not yet supported](https://github.com/dependabot/dependabot-core/issues/3290) by `dependabot`.  Hopefully it will be updated soon.  For now I have left the `dependabot` setup on this repository to show what it will look like once it is working again.  Dependabot currently works when dependencies are defined in `requirements.txt`, the old `setup.py`, or using `poetry`s version of a `pyporject.toml` file (the format is not standard).
 ```
 
-where `data_transforms` is the name of the python package we are writing in this workshop.
+## Installing your package locally
+
+When you install a python package it will typically involve copying the python files to your `site-packages` directory.  Running `pip install .[dev]` in the top level directory (same folder as the `pyproject.toml` file) will do just this.  If you are actively developing your code and want to test out your latest changes you would need to reinstall the code with every change, this can become tedious.
+
+To help developers, `pip` also has the ability to install a package in "edit" mode, this creates a symbolic link in `site-packages` that points to your source code, that way change can be seen without needing to reinstall the code.
+
+```bash
+pip install -e .[dev]
+```
+
+## Versioning your package
+
+It is a good idea to use single-source package versioning, this means the package version is defined in exactly one place inside the repository.  For python this is typically inside the top level `__init__.py` file and stored with the variable name `__version__`.  `flit` will automatically pull the version number from this place and use it in the `pyporject.toml` file (this is why "version" is listed in the `dynamic` section)
 
 When you are ready to release a new version of your code make a new PR that only bumps the version number using semantic versioning (see note above).  Once merged add a git tag to the merge commit.  You can also add additional notes about the release when making the tag, this a good place to include what things have changed in the new release.
 
 For larger projects it is worth keeping a separate `CHANGELOG.md` file inside the repository or a changelog section in the `README.md` that tracks all the changes introduced in each version bump to make this information easier to find.  There are tools available to help automate this process, these typically involve using special keywords when writing git commit messages to flag up text related to new features and/or breaking changes (e.g. [auto-changelog](https://github.com/KeNaCo/auto-changelog)).
+
+## Build artifacts
+
+If/when you are ready to upload your files to `PyPI` you first need to crete the files that will be uploaded.  These can be done with our chosen build tool:
+
+```bash
+flit build
+```
+
+This will create two files in the `dist` subdirectory:
+
+- `data_transforms-0.1.0.tar.gz`: this is the `sdist` file, a normal zip folder with the source code inside
+- `data_transforms-0.1.0-py3-none-any.whl`: this is the `wheel` file, also a zip folder with the pre-compiled code inside (if you code is pure python it will be basically identical to the `sdist` in contents)
+
+The code version number automatically used in the build names, this prevents older code version from being overwritten when the version is updated.
+
+## Build upload
+
+To publish your package to [PyPI](https://pypi.org/) you will first need to create an account.  Once created you can use your build tool or [twine](https://twine.readthedocs.io/en/stable/) to upload your build artifacts.  For uploading with `flit` see their docs [https://flit.pypa.io/en/latest/upload.html](https://flit.pypa.io/en/latest/upload.html).
+
+```{note}
+The build and upload systems can be written into a GHA that triggers when a new version is tagged so you never forget the step of releasing your code to the public.
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,13 @@ dev = [
 Documentation = "https://ckrawczyk.github.io/DISCnet_workshop/"
 Source = "https://github.com/CKrawczyk/DISCnet_workshop"
 
+[tool.flit.sdist]
+exclude = [
+    "docs/",
+    "example_data/",
+    "build_docs.sh"
+]
+
 [tool.coverage.run]
 omit = ["*test*"]
 source = ["data_transforms"]


### PR DESCRIPTION
Whit the switch to `flit` the notes needed to be updated.  A new section was added about python build tools and what they do.

I also moved the code structure notes into their own file.