### PR TITLE
Organize dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,18 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = [
+test = [
     "coverage[toml] >=6.3.2,<6.3.3",
     "flake8 >=4.0.1,<4.0.2",
+]
+doc = [
     "myst-nb >=0.15.0,<0.15.1",
     "sphinx >=4.5.0,<4.5.1",
     "sphinx_rtd_theme >=1.0.0,<1.0.1"
+]
+dev = [
+    "data_transforms[test]",
+    "data_transforms[doc]"
 ]
 
 [project.urls]


### PR DESCRIPTION
Split `dev` into `test` and `doc` to make it more clear what each dependency does.