### PR TITLE
Remove warning about dependabot

### DIFF
--- a/docs/source/code_structure.md
+++ b/docs/source/code_structure.md
@@ -25,7 +25,7 @@ It is difficult to review code if you don't know what task the code it trying to
 - Make sure the tone of your comments matches who you expect to be reading them
     - Comments targeted at people learning python syntax for the first time should look different than comments targeted at people who have been using python for several years
 - Stick to a consistent coding style
-- Keep in mind your reviewer will be mostly looking at code diffs, so put some thought how you changes will look in that format.  As and example if the following code changed from:
+- Keep in mind your reviewer will be mostly looking at code diffs, so put some thought how your changes will look in that format.  As and example if the following code changed from:
 
 ```python
 a = {'b': 2, 'c': 3, 'd': {'e': 5, 'f': 6}}

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -60,7 +60,7 @@ pip install -U pip flit
 pip install -e .[dev]
 ```
 
-The option `-e` installs the code in "edit" mode, this means the package directory is sym-linked into your python path.  Any changes you make to the code will automatically be "install" without needing to run the `pip` command again.  `.[dev]` indicates you want to install the python package located in the current folder and to also install the optional development dependencies for the package.  We will cover these topics in more detail in the "packaging python code" section of the workshop.
+The option `-e` installs the code in "edit" mode, this means the package directory is sym-linked into your python path.  Any changes you make to the code will automatically be "installed" without needing to run the `pip` command again.  `.[dev]` indicates you want to install the python package located in the current folder and to also install the optional development dependencies for the package.  We will cover these topics in more detail in the "packaging python code" section of the workshop.
 
 ## Running tests
 The notes on test driven development will go into this in more detail, but for completeness you can run this codes tests with the command:

--- a/docs/source/github_with_collaborators.md
+++ b/docs/source/github_with_collaborators.md
@@ -25,17 +25,17 @@ While many of you might already be familiar with Git, let's make sure we are all
   - A Git repository that is on the internet
   -
 * - Pull from remote
-  - "Pulling" the changes on the remote to you local
+  - "Pulling" the changes from the remote to you local repository
   - ```bash
     git pull
     ```
 * - Push to remote
-  - "Pushing" local change to the remote
+  - "Pushing" changes from the local to the remote repository
   - ```bash
     git push
     ```
 * - Staging changes
-  - Adding files to be in the next commit
+  - Adding files to be included in the next commit
   - ```bash
     git add <file name>
     ```
@@ -57,11 +57,12 @@ While many of you might already be familiar with Git, let's make sure we are all
 * - Merge
   - Merging two branches together
   - ```bash
+    # merge <branch name> into the main branch
     git checkout main
     git merge <branch name>
     ```
 * - Tag
-  - Naming a commit to make it easier to find in the future
+  - Naming a commit to make it easier to find in the future (typically new code release versions are tagged)
   - ```bash
     git tag <tag name>
     ```
@@ -108,38 +109,43 @@ There are many different ways to effectively use git within a collaboration, and
 5. assign a reviewer for your PR (it is your job to ask someone to look at your code, don't expect the PR to "just be seen" by other developers)
 6. address any feedback left by the reviewer
 7. once approved **rebase** your changes onto the latest `main` branch to ensure there are no code conflicts
-or if you want to clean up your git history (e.g. merge two commit together, change your commit messages, etc...) rebase in interactive mode (`git rebase -i main`)
+or if you want to clean up your git history rebase in interactive mode (`git rebase -i main`)
 8. push the rebased code back to the remote
 9. merge to the `main` branch using the big green button
 10. delete the brach on the remote once the merge is finish
 11. pull the latest `main` (with your PR merged) locally
 12. (optional) delete your local copy of the merged branch
 
+```{note}
+After the rebase when you go to push to the back to the remote (step 8) you will need to use `--force-with-lease` switch.  This is needed if any of the git history is re-written during the rebase.  This switch is a slightly safer version of `--force` where it will only let you continue if you are not overwriting the work of a different developer on the same branch.  This can prevent you from accidentally deleting someone else's work.
+```
+
+And these steps in code:
 ```bash
 # get latest code on main branch
 git checkout main
 git pull
 
 # make new working branch
-git checkout -b my-feature-branch
+git checkout -b feature/my-feature-branch
 git add my_new_file.py
 git commit
-git push --set-upstream origin my-feature-branch
+git push --set-upstream origin feature/my-feature-branch
 # make PR on GitHub
 
 # get latest changes to main and rebase
 git checkout main
 git pull
-git checkout my-feature-branch
+git checkout feature/my-feature-branch
 git rebase main
-git push --force-with-lease origin my-feature-branch
+git push --force-with-lease origin feature/my-feature-branch
 
 # after merge on GitHub update your main branch
 git checkout main
 git pull
 
 # clean up
-git branch -d my-feature-branch
+git branch -d feature/my-feature-branch
 ```
 
 
@@ -204,7 +210,7 @@ This section of notes is partially adapted from gov.uk's style guides found at:
 
 - [https://github.com/alphagov/styleguides/blob/master/pull-requests.md](https://github.com/alphagov/styleguides/blob/master/pull-requests.md)
 
-Once you have a branch with some commits you want to merge into the main branch, the next step is to have those changes reviewed by another developer.  On GitHub this process is known as creating a Pull Request (PR).  When opening a PR you should provide a detailed description of changes introduced, the reason the changes were made, and any specific things they reviewer should be aware of when testing your code.  If the PR is in references to an open issue on the repo this should be mentioned as well.
+Once you have a branch with some commits you want to merge into the main branch, the next step is to have those changes reviewed by another developer.  On GitHub this process is known as creating a Pull Request (PR).  When opening a PR you should provide a detailed description of changes introduced, the reason the changes were made, and any specific things the reviewer should be aware of when testing your code.  If the PR is in reference to an open issue on the repo this should be mentioned as well.
 
 ## Writing better code reviews
 
@@ -215,6 +221,8 @@ When working in a team it is important to review other people's code along side 
 git checkout main
 git pull  # also fetches the names of all remote branches
 git checkout <name of branch on remote>
+# or in newer versions of git
+git switch <name of branch on remote>
 ```
 2. Read the PR to see what changes were made
 3. Test that those changes work as intended
@@ -223,7 +231,7 @@ git checkout <name of branch on remote>
 4. If the PR is fixing a bug:
     - Reproduce the bug on `main`
     - Switch to the PRs branch and ensure the bug is fixed
-5. Look over the code diff on GitHub and leave inline comments you have about any of the lines
+5. Look over the code diff on GitHub and leave inline comments
     - Questions about how code works
     - Suggestions for make the code easier to read and/or more efficient
 6. Write your review (GitHub supports full markdown, don't be afraid to use section headings and lists in your review)
@@ -233,7 +241,7 @@ git checkout <name of branch on remote>
     - If appropriate list any consequences of the changes (e.g. is there other code that should be changed in a future PR as a result)
     - Any actions the PRs author(s) should take before merging
 7. Either approve or block (pending changes) the PR
-8. If approved you are done, it is the responsibility of the author(s) to merge the PR.  If not re-review when the changes asked for are finished.
+8. If approved you are done, it is the responsibility of the author(s) to merge the PR.  If not re-review when the changes you asked for are finished.
 
 Here is an example of well constructed PR and review taken from one of the Zooniverse's repositories [https://github.com/zooniverse/front-end-monorepo/pull/2313](https://github.com/zooniverse/front-end-monorepo/pull/2313).
 

--- a/docs/source/good_coding_practices.md
+++ b/docs/source/good_coding_practices.md
@@ -16,15 +16,15 @@ Ways to boost context transfer:
 
 Although there are numerous IDEs (e.g. IDLE, Spyder) for python, for most everyday use you will likely be writing python code in a text editor and running your programs via the command line.  In this case it is important to have a good text editor that supports syntax highlighting, live linting (syntax and style checking), and is easy to configure the way you want.  I can highly recommend [VScode](https://code.visualstudio.com/) as a free text editor with all the features above.
 
-For python coding in VScode you will want to install the `Python` extension by Microsoft (you will be prompted to install it when you first open a `.py` file) and the `Jupyter` extension by Microsoft.  Other useful extensions are the `Excel Viewer` extension for easier viewing CSV files, `open in browser` for and option to open HTML files in your browser, `MyST-Markdown` for rendering markdown files, and `Code Spell Checker` for basic spell checking.
+For python coding in VScode you will want to install the `Python` extension by Microsoft (you will be prompted to install it when you first open a `.py` file) and the `Jupyter` extension by Microsoft.  Other useful extensions are the `Excel Viewer` extension for easier viewing of CSV files, `open in browser` for and option to open HTML files in your browser, `MyST-Markdown` for rendering markdown files, and `Code Spell Checker` for basic spell checking.
 
 ```{note}
-The most important part for a text editor is you are comfortable using it.  Feel free to try out different ones to fine what works best for you.
+The most important part for a text editor is that you are comfortable using it.  Feel free to try out different ones to find what works best for you.
 ```
 
 ### Programming fonts
 
-In addition to a good text editor you will also want a good monospace font.  I can recommend [FiraCode](https://github.com/tonsky/FiraCode).  This font has ligatures (special characters used represent specific letters that appear next to each other) that help when reading code (e.g. turing `>=` int a "less-than or equal" to sign).
+In addition to a good text editor you will also want a good monospace font.  I can recommend [FiraCode](https://github.com/tonsky/FiraCode).  This font has ligatures (special characters used to "connect" specific letters that appear next to each other) that help when reading code (e.g. turing `>=` int a "less-than or equal" to sign).
 
 ````{note}
 Use this font in VScode you will want to install the `Disable Ligatures` extension to allow the ligatures to be turned off on the line you are currently typing and set the following options in VScode's `settings.json` file:
@@ -43,7 +43,7 @@ All other font options (such as font size) can be set from the normal settings p
 
 ## Coding style and linting
 
-What is a coding style?  Beyond the syntax of a coding language, a coding style is a set of conventions that can be followed to make it easier for other developers (including your future self) to read you code and to understand the intention behind your code.  For python coding the style most developers use has it basis in [PEP 8](https://peps.python.org/pep-0008/).
+What is a coding style?  Beyond the syntax of a coding language, a coding style is a set of conventions that can be followed to make it easier for other developers (including your future self) to read you code and to understand the intention behind your code.  For python coding [PEP 8](https://peps.python.org/pep-0008/) is used as the *base* for most styles.
 
 >A style guide is about consistency. Consistency with this style guide is important. Consistency within a project is more important. Consistency within one module or function is the most important.
 
@@ -59,7 +59,7 @@ Here are some examples of PEP 8 conventions:
 
 While you could read over PEP 8 and try to memorize it, the most effective way to lean (and stick to) PEP 8 standards is to use a linter for you code.  A linter is a package that will automatically check your code style through a command line function.  Some text editors support live linting to check your code style as you type your code (similar to a spell checker).
 
-The two most common linters used for python are [pylint](https://pylint.pycqa.org/en/latest/) and [flake8](https://flake8.pycqa.org/en/latest/).  While both cover the standard PEP 8 rules, they each have a different set of additional style rules that are checked (i.e. checking for things like unused `import`s).  Of the two `flake8` is a bit less opinionated making it a bit easier to get on with when first learning to stick to a style, because of this we will be using it for the workshop. Once `flake8` is install you can run it on the command line with:
+The two most common linters used for python are [pylint](https://pylint.pycqa.org/en/latest/) and [flake8](https://flake8.pycqa.org/en/latest/).  While both cover the standard PEP 8 rules, they each have a different set of additional style rules that are checked (i.e. checking for things like unused `import`s).  Of the two `flake8` is a less opinionated making it a bit easier to get on with when first learning to stick to a style, because of this we will be using it for the workshop. Once `flake8` is install you can run it on the command line with:
 
 ```bash
 flake8
@@ -71,14 +71,14 @@ To set up VScode to use `flake8` open the settings, search for `python linting`,
 
 ### Configuring your linter
 
-While `flake8` is a great starting point, it is just that, a starting point.  PEP 8 should be used as a guideline for your projects style and if there are any rules you don't agree with you are free to turn them off.  While this can be configured globally on your local computer, I would recommend doing at the project level inside your code's `setup.cfg` file.  By doing it at the project level your choice of style rules will be saved **inside the project** for all developers to see and use.
+While `flake8` is a great starting point, it is just that, a starting point.  PEP 8 should be used as a guideline for your projects style and if there are any rules you don't agree with you are free to turn them off.  While this can be configured globally on your local computer, I would recommend doing at the project level inside your code's `.flake8` file.  By doing it at the project level your choice of style rules will be saved **inside the project** for all developers to see and use.
 
 In particular, the `flake8` rules [W503](https://www.flake8rules.com/rules/W503.html) and [W504](https://www.flake8rules.com/rules/W504.html) are the exact opposite of each other, so one of them must be ignored.  Within this project I have already set up the `flake8` configuration in the `.flake8` file so it will:
 
 - ignore the project configuration folders (.git, docs, etc...)
 - Set the max line length to 120
 - Turn off rule `W503`
-- Turn off `BLK100` (flake-black, black is an optional set of rules we are not going to be using)
+- Turn off `BLK100` (flake-black is an optional set of rules we are not going to be using)
 
 ```{note}
 [Black](https://black.readthedocs.io/en/stable/) is a code auto-formatter.  It will take the code you have written, and where possible, make it follow a consistent style.  By construction it **is not** configurable and **is** very opinionated.  If you like the [style it produces](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html) feel free to use it.

--- a/docs/source/packaging_python_code.md
+++ b/docs/source/packaging_python_code.md
@@ -15,13 +15,17 @@ A build system typically comes with a command line interface (CLI) that can auto
 Common build systems are:
 - [flit](https://flit.pypa.io/en/latest/): just a build system, nothing more
 - [hatch](https://hatch.pypa.io/latest/): build system and environment management
-- [pdm](https://pdm.fming.dev/latest/): build system, dependency management, dependency locking, and environment management (note: the environments are handled in the background so you don't have to do it by hand)
+- [pdm](https://pdm.fming.dev/latest/): build system, dependency management, dependency locking, and environment management
 - [poetry](https://python-poetry.org/docs): build system, dependency management, dependency locking, and environment management (note: not [PEP 621](https://peps.python.org/pep-0621/) compliant, but it is on their long-term [feature road map](https://github.com/python-poetry/roadmap/issues/3))
 
 Each of these build systems have different workflows when managing your python package, it can be useful to try some of them out and see what one fits your project best.
 
 ```{note}
-Python's packaging landscape is currently (Summer 2022) in flux.  You will find many out of date tutorials around making a `setup.py` and/or `setup.cfg` instead of/in addition to the `pyproject.toml`.  As of [PEP 621](https://peps.python.org/pep-0621/) (approved in 2021), the method outlined in these notes is the "approved python" way of making a package going forward.  As of `pip` version 22.1.2 this new way of packaging is fully supported. 
+Python's packaging landscape is currently (Winter 2023) in flux.  You will find many out of date tutorials around making a `setup.py` and/or `setup.cfg` instead of/in addition to the `pyproject.toml`.  As of [PEP 621](https://peps.python.org/pep-0621/) (approved in 2021), the method outlined in these notes is the "approved python" way of making a package going forward.  As of `pip` version 22.1.2 this new way of packaging is fully supported. 
+```
+
+```{note}
+What about Conda?  Technically Conda is a *system* package manager that includes a python package manager inside, this makes is easier to declare dependencies from other programming languages such as C and Fortran.  Because of this Conda only provides built packages against specific system architectures (no source distributions).  It split of from standard python before Python wheels were defined and as a result has a very different way of defining a python package's metadata.  We will not be covering this topic in this workshop and will rather stick with the current python standard.
 ```
 
 ## The source code structure
@@ -36,16 +40,17 @@ DISCnet_workshop (git repository)
 │       ├── __init__.py
 │       └── test_angle_metric.py (test file)
 ├── LICENSE (make sure you license your code)
-├── README.md (shown on the github page)
-└── pyproject.toml (contains package metadata and dependencies)
+├── README.md (shown on the github landing page)
+├── pyproject.toml (contains package metadata and dependencies)
+└── docs (folder with documentation files)
 ```
 
-- `__init__.py`: A python package treats every folder as a class with this file as the initialization function, useful for pulling functions from the files and folders inside this folder into the top level namespace.  The top level `__init__.py` typically also stores the package `__version__` variable.
+- `__init__.py`: A python package treats every folder as a class with this file as the initialization function, useful for creating a top level namespace for all the functions contained in the folder.  The top level `__init__.py` typically stores the package's `__version__` variable.
 - `LICENSE`: You should choose a license for your code. [Choose A License](https://choosealicense.com/) is a good resource for figuring out what license is best for your project.  The typical ones seen for research code are the [MIT license](https://choosealicense.com/licenses/mit/) and [Apache 2.0 license](https://choosealicense.com/licenses/apache-2.0/).
 - `pyproject.toml`: This file tells python how to install your code, what dependencies to install, and various development configuration options.  You can use `flit init` to help build this file or just write it by hand.
 
 ## Setting dependency versions
-To help with code reproducibility and dependency compatibility you can should pin dependency versions to a single value or a range.  It is python convention that the dependencies in `pyproject.toml` are unpinned or pinned as **ranges** to ensure they are easy to install into existing environments and not collide with the dependencies of other packages installed.  An optional file (either `requirements.txt` or the lock file created by your build tool) is used to pin down **exact** package versions when reproducibility is important (e.g. all the developers wanting to have the same versions of dependencies installed, keeping a record of the package versions installed when a paper was published using the code, or ensuring web apps deploy with the same versions the tests ran with).
+To help with code reproducibility and dependency compatibility you can should pin dependency versions to a single value or a range.  It is python convention that the dependencies in `pyproject.toml` are unpinned or pinned as **ranges** to ensure they are easy to install into existing environments and not collide with the dependencies of other packages installed.  An optional file (either `requirements.txt` or a lock file created by your build tool) is used to pin down **exact** package versions when reproducibility is important (e.g. when you want all the developers to have the same versions of dependencies installed, keeping a record of the package versions installed when a paper was published using the code, or ensuring web apps deploy with the same versions used to run the tests).
 
 ```{note}
 Most python packages use [semantic versioning](https://semver.org/).  This means the version numbers are set as MAJOR.MINOR.PATCH 
@@ -63,7 +68,7 @@ The rule of thumb I use when pinning down my packages ranges:
 ## Installing your package locally
 When you install a python package it will typically involve copying the python files to your `site-packages` directory.  Running `pip install .[dev]` in the top level directory (same folder as the `pyproject.toml` file) will do just this.  If you are actively developing your code and want to test out your latest changes you would need to reinstall the code with every change, this can become tedious.
 
-To help developers, `pip` also has the ability to install a package in "edit" mode, this creates a symbolic link in `site-packages` that points to your source code, that way change can be seen without needing to reinstall the code.
+To help developers, `pip` also has the ability to install a package in "edit" mode, this creates a symbolic link in `site-packages` that points to your source code, that way change can be seen without needing to reinstall the code (but you will still need to re-start the python interpreter to see code changes).
 
 ```bash
 pip install -e .[dev]

--- a/docs/source/packaging_python_code.md
+++ b/docs/source/packaging_python_code.md
@@ -45,7 +45,7 @@ DISCnet_workshop (git repository)
 - `pyproject.toml`: This file tells python how to install your code, what dependencies to install, and various development configuration options.  You can use `flit init` to help build this file or just write it by hand.
 
 ## Setting dependency versions
-To help with code reproducibility and dependency compatibility you can should pin dependency versions to a single value or a range.  It is python convention that the dependencies in `pyproject.toml` are pinned as **ranges** to ensure they are easy to install into existing environments and not collide with the dependencies of other packages installed.  An optional file (either `requirements.txt` or the lock file created by your build tool) is used to pin down **exact** package versions when reproducibility is important (e.g. all developers wanting to have the same versions of all dependencies installed or keeping a record of the package versions installed when a paper was published using the code).
+To help with code reproducibility and dependency compatibility you can should pin dependency versions to a single value or a range.  It is python convention that the dependencies in `pyproject.toml` are unpinned or pinned as **ranges** to ensure they are easy to install into existing environments and not collide with the dependencies of other packages installed.  An optional file (either `requirements.txt` or the lock file created by your build tool) is used to pin down **exact** package versions when reproducibility is important (e.g. all the developers wanting to have the same versions of dependencies installed, keeping a record of the package versions installed when a paper was published using the code, or ensuring web apps deploy with the same versions the tests ran with).
 
 ```{note}
 Most python packages use [semantic versioning](https://semver.org/).  This means the version numbers are set as MAJOR.MINOR.PATCH 
@@ -59,10 +59,6 @@ The rule of thumb I use when pinning down my packages ranges:
 - Set the upper bound as `<` the next patch fix version of the package
 - Activate [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) on GitHub to automatically make pull requests that update the upper bound when dependencies update (this will trigger our CI to run our tests automatically and let us know if the update breaks the code)
     - If a dependency update breaks the code (typically major version updates), update the code and set the lower bound to be the latest version of the dependency
-
-```{warning}
-Related to the current changing landscape of Python packaging the packaging method in this workshop is [not yet supported](https://github.com/dependabot/dependabot-core/issues/3290) by `dependabot`.  Hopefully it will be updated soon.  For now I have left the `dependabot` setup on this repository to show what it will look like once it is working again.  Dependabot currently works when dependencies are defined in `requirements.txt`, the old `setup.py`, or using `poetry`s version of a `pyporject.toml` file.
-```
 
 ## Installing your package locally
 When you install a python package it will typically involve copying the python files to your `site-packages` directory.  Running `pip install .[dev]` in the top level directory (same folder as the `pyproject.toml` file) will do just this.  If you are actively developing your code and want to test out your latest changes you would need to reinstall the code with every change, this can become tedious.

--- a/docs/source/test_driven_development.md
+++ b/docs/source/test_driven_development.md
@@ -1,19 +1,19 @@
 # Test driven development
-When writing code you want to make sure the code works as intended, when bugs are found that then don't come back, and the code being written can solve the desired research question.  Test driven development is a way to systematically achieve all of these goals.
+When writing code you want to make sure the code works as intended, previously identified bugs stay fixed, and the code being written can solve the desired research question.  Test driven development is a way to systematically achieve these goals.
 
 ## What are tests
-The basic function of a test is to take in a given input to your code that has **a known** output, run your code on the input, and check that the output matches your expectations.  The key here is the known output you are testing against comes from some source that is **not** your code (e.g. an analytic solution, work it out by hand, some other code you know works, etc...).
+The basic function of a test is to pass a given input to your code that has **a known** output and check that the output matches your expectations.  The key here is the known output you are testing against comes from some source that is **not** your code (e.g. an analytic solution, work it out by hand, some other code you know works, etc...).
 
-These test cases are written as functions within your code and can be run at any time to ensure any changes made in the code have not broken any of the tests.  Using CI you can set up your code repository to run your tests any time a new PR is made and block the PR from merging if any of the tests fail.
+These test cases are written as functions within your code and can be run at any time to ensure any changes made in the code have not broken these test cases.  Using CI you can set up your code repository to run these tests any time a new PR is made and block the PR from merging if any of the tests fail.
 
-When bugs arise in your code, it is best practice to first write a new test that reproduces the bug before fixing the bug.  That way you can be sure the bug it identified, fixed, and changes made in the future will not reintroduce the same bug into your code.
+When bugs arise in your code, it is best practice to first write a new test that reproduces the bug before fixing the bug.  That way you can be sure the bug is identified, fixed, and changes made in the future will not reintroduce the same bug into your code.
 
-Once you become comfortable with writing tests you may find it easier to write your tests first and the code second.  Doing this encourages you to think about the main goals of the code you are about to write, and when the tests pass you know the code is finished.
+Once you become comfortable with writing tests you may find it easier to write your tests first and the code second.  Doing this encourages you to think about the main goals of the code you are about to write, and when the tests pass you know the code is finished.  This process of writing the test first is know as test driven development.
 
 ## Python's built in unittest library
 Python comes with a built in testing library called [unittest](https://docs.python.org/3/library/unittest.html) that includes full object mocking capabilities.  Unittest organizes tests into classes (subclassed from `unittest.TestCase`) where each test is a method on the class that has a name starting with `test_`.  There are also special `setUp` and `tearDown` methods that, if defined, will run before and after *each* test method.  This class also provides various assert functions such as `self.assertEqual`, `self.assertDictEqual`, and `self.assertGreater` (see [API documentation for full list](https://docs.python.org/3/library/unittest.html)) that provide more useful error messages when they fail than a plain `assert` statement does.  All the examples in this workshop use `unittest`'s framework and syntax. 
 
-Python will auto-discover any tests that are in your current directory by looking for any files that follow the pattern `test*.py` by default (this search pattern can be changed when the unittest command is run).  The test file must be importable from the top level directory of the project (i.e. `__init__.py` in the folders containing any tests).  To run the tests use the command:
+Python will auto-discover any tests that are in your current directory by looking for any files that follow the pattern `test*.py` by default (this search pattern can be changed when the unittest command is run).  The test file must be importable from the top level directory of the project (i.e. a blank `__init__.py` is in the folders containing any tests).  Test can be run with the command:
 
 ```bash
 python -m unittest discover
@@ -25,7 +25,7 @@ If this command does not find your tests you can specify various command line op
 The other commonly used python testing library is [pytest](https://docs.pytest.org/en/latest/).  It has its own syntax for writing tests that is more compact than `unittest`, but can come at the cost of clarity for more complex tests.  Pytest is also fully compatible with tests written in `unittest` syntax.
 
 ```{note}
-VScode uses `pytest` to run tests inside the editor, if you are using `unittest`'s `self.subTest` syntax you will need to install the [pytest-subtests](https://github.com/pytest-dev/pytest-subtests) package for to run them.
+VScode uses `pytest` to run tests inside the editor, if you are using `unittest`'s `self.subTest` syntax you will need to install the [pytest-subtests](https://github.com/pytest-dev/pytest-subtests) package for them to run as expected.
 ```
 
 ```{warning}
@@ -33,7 +33,7 @@ You might also see [nosetest](https://nose.readthedocs.io/en/latest/) used by so
 ```
 
 ## Types of tests
-There are several flavors of tests that can be written for code.  The main there that I have come across are:
+There are several flavors of tests that can be written for code.  The main three I have come across are:
 - Unit tests
 - Integration tests
 - Validation tests
@@ -41,11 +41,11 @@ There are several flavors of tests that can be written for code.  The main there
 While these are not the only three types of tests, they are a good starting point for writing your own tests.  
 
 ```{note}
-These are the names that make the most sense to me, but others might use different names.
+These are the names that make the most sense to me, but others might use different names for the same kinds of tests.
 ```
 
 ### Unit tests 
-The goal of unit tests are to test a "unit" of code (e.g. a single function definition or a single class method) in **isolation** from all the other units of code that make up the software.  These test are mostly for checking if the unit of code works as written (i.e. the algorithm was coded correctly).
+The goal of unit tests are to test a "unit" of code (e.g. a single function definition or a single class method) in **isolation** from all the other units of code that make up the software.  These test are mostly for checking if the unit of code works as written (i.e. the algorithm was coded correctly).  Here is an example of a simple unit test:
 
 ```python
 def func(a, N=1):
@@ -72,7 +72,7 @@ class TestFunc(unittest.TestCase):
 ```
 
 ### Integration tests
-The goal of integration tests are to test if multiple units of code work **together** correctly.  For example if you had a function who's only job is to call two other functions in a particular order and pass the results from one function into the next, an integration test would check exactly these things.  It would **not** check that the two sub-functions return that correct values (that is the job of a unit test for those sub-functions), just that that values passed back are sent to the correct place.
+The goal of integration tests are to test if multiple units of code work **together** correctly.  For example if you had a function who's only job is to call two other functions in a particular order and pass the results from one function into the next, an integration test would check exactly these things.  It would **not** check that the two sub-functions return the correct values (that is the job of a unit test for those sub-functions), just that that values passed back are sent to the correct place.
 
 ```python
 def func_1(a):
@@ -128,14 +128,14 @@ When writing integration tests (or any tests using mocks) it is very easy to mak
 
 To help avoid this, when you have finished writing a test read it over and ask yourself "what is the main goal of the code being tests and do these test check **only** that?  Is a future refactor likely to break this test?"
 
-If the main goal `run_all` is to get the expected result out the other end, the unit test is sufficient.  If the main goal of `run_all` is to composite `func_1` and `func_2` the integration test is sufficient.
+If the main goal `run_all` is to get the expected result out the other end, the unit test is sufficient.  If the main goal of `run_all` is to compose `func_1` and `func_2` the integration test is sufficient.
 ```
 
 ### Validation tests
 The goal of validation tests are to check if the code written is appropriate for problem you are trying to solve (i.e. is the code using the correct algorithm).  For example, can you get away with using a 2nd order ODE integrator or do you need to using a 4th order one to keep the desired level of accuracy.  Often these are just a flavor of an integration test or unit test, but with "science quality" data being passed in.
 
 ## Test coverage
-Test coverage is a way of tracking what lines of your code were run when each of your tests ran.  When writing tests for a function you goal should be to have as much coverage as possible.  This typically means making sure you have at least one test for every branch in your code (i.e. one test for each `if` branch in the code).  Sometimes when writing your tests you will realize that there are branches in your code that can never be reached and can be safely removed from the code.
+Test coverage is a way of tracking what lines of your source code were run when each of your tests ran.  When writing tests for a function you goal should be to have as much coverage as possible.  This typically means making sure you have at least one test for every branch in your code (i.e. one test for each `if` branch in the code).  Sometimes when writing your tests you will realize that there are branches in your code that can never be reached and can be safely removed from the code.
 
 To check test coverage you can use the [coverage package](https://coverage.readthedocs.io/en/latest/), once installed it will wrap around your chosen test runner and check how many lines of you package's code were run by your tests.  After the tests are run you can generate a report to see how many lines were covered.  The basic usage is:
 
@@ -146,11 +146,11 @@ coverage report --show-missing
 
 The options passed to `run` are:
 - `--source data_transforms`: base folder for the package
-- `--omit *test*`: patter of files not to include in coverage percent
+- `--omit *test*`: pattern of files not to include in coverage percent
 - `-m unittest discover`: the test runner command
 
 The option passed to `report` is:
-- `--show-missing`: for each file list the line number(s) not covered by a test
+- `--show-missing`: for each file list the line number(s) not covered by any tests
 
 These extra command line options can be included in your project's `pyproject.toml` file (already done in this workshop's repo) to simplify these commands to:
 
@@ -176,13 +176,15 @@ The main use of mocks are:
 - ensuring that bugs in sub-functions don't make other functions' tests fail (i.e. only testing the code you wrote and not the code coming from other packages). 
 - avoid having to read/write data to disk (`unittest.mock.mock_open` is its own function that helps when you need to test code that opens files)
 
-Example, we want to mock away class that has several methods (we will use a `with` block this time instead of the decorator syntax):
+Example, we want to mock away a class that has several methods (we will use a `with` block this time instead of the decorator syntax):
 
 ```python
 from unittest.mock import patch, call
 
-
+# make an instance of a class we will mock
 thing = object()
+
+# Set what the mocked `method_1` and `method_2` should return
 config = {
     'method_1.return_value': 5,
     'method_2.side_effect': [1, 2, 3]
@@ -200,19 +202,19 @@ with patch('__main__.thing', **config) as mock_MyClass:
     mock_MyClass.method_1.assert_called_once()
 
     # check method_2 returns each values set in turn
-    assert thing.method_2(a=1) == 1
-    assert thing.method_2(a=2) == 2
-    assert thing.method_2(a=3) == 3
+    assert thing.method_2(a=5) == 1
+    assert thing.method_2(a=6) == 2
+    assert thing.method_2(a=7) == 3
 
     # how to test it was called three times with specific arguments/keywords each time
     expected_calls = [
-        call(a=1),
-        call(a=2),
-        call(a=3)
+        call(a=5),
+        call(a=6),
+        call(a=7)
     ]
     mock_MyClass.method_2.assert_has_calls(expected_calls, any_order=False)
 
-    # how to test it was called three times with any arguments/keywords
+    # how to test it was called three times (without specifying the explicit calls)
     assert mock_MyClass.method_2.call_count == 3
 
     # any method and return value generates a new mock that tracks calls

--- a/docs/source/the_task.md
+++ b/docs/source/the_task.md
@@ -2,7 +2,7 @@
 In this workshop we will all be helping to write a single python package.  This package will be used to process the results of a [test Zooniverse project](https://www.zooniverse.org/projects/cmk24/testing/classify).  In this Zooniverse project volunteers are asked to answer some questions, count, and draw features on stock images of cats.
 
 ## The data
-The data comes as a [Zooniverse classification export](https://help.zooniverse.org/next-steps/data-exports/#classification-export), a CSV file containing one row for every classification made on the project.  An example of this data file can be found in the `example_data` folder of the repository.  The link above contains an explanation of what data is contained within the file, we will mostly be working with the `annotations` column for this workshop.
+The data comes as a [Zooniverse classification export](https://help.zooniverse.org/next-steps/data-exports/#classification-export), a CSV file containing one row for every classification made on the project.  An example of this data file can be found in the [example_data](https://github.com/CKrawczyk/DISCnet_workshop/tree/main/example_data) folder of the repository.  The link above contains an explanation of what data is contained within the file, we will mostly be working with the `annotations` column for this workshop.
 
 The project's workflow has:
 - A question task (task label `T0`)
@@ -20,7 +20,7 @@ For this data analysis we want to do two things:
 2. **Reduce** all extracts from the same subject to find a consensus answer for each task
 
 ```{note}
-This workshop is more focused on "how to write code" more than the results of the data analysis.  Don't worry about getting the analysis "correct" or even finishing both tasks above, instead focus on the process of writing code as a team.
+This workshop is more focused on "how to write code" rather than the results of the data analysis.  Don't worry about getting the analysis "correct" or even finishing both tasks above, instead focus on the process of writing code as a team.
 ```
 
 ## The code structure

--- a/docs/source/writing_documentation.md
+++ b/docs/source/writing_documentation.md
@@ -1,5 +1,5 @@
 # Documenting Python code
-When someone unfamiliar with your code first wants to use your code, the first place they will look is you documentation.  It is good practice for your documentation to start with a brief description of what your package does (1-2 paragraphs) and clear instructions for how to install the code.
+When someone new is using your code for hte first time they will likely want to read your documentation to see how the code works.  It is good practice for your documentation to start with a brief description of what your package does (1-2 paragraphs) and clear instructions for how to install the code.
 
 To help ensure that the source code and the documentation don't get out of sync, the documentation for each function should be included as a docstring on the function in the source code.  In python this is done with a "triple quote string":
 
@@ -9,7 +9,7 @@ def sum_two_numbers(a, b):
     return a + b
 ```
 
-Or a more explicit docstring (using [numpy's style guide](https://numpydoc.readthedocs.io/en/latest/format.html#style-guide)):
+Or a more explicit docstring (using [numpy's documentation style guide](https://numpydoc.readthedocs.io/en/latest/format.html#style-guide)):
 
 ```python
 def sum_two_numbers(a, b):
@@ -30,7 +30,7 @@ def sum_two_numbers(a, b):
     return a + b
 ```
 
-In addition to the API documentation from the docstrings you should also provide tutorials on how to use you code (python notebooks work great for this kind of documentation).  You can also provide additional information in markdown format (like these notes you are reading now).
+In addition to the API documentation from the docstrings you should also provide tutorials on how to use your code.  Python notebooks work great for this kind of documentation.  You can also provide additional information in markdown files (like these notes you are reading now).
 
 ## Sphinx
 Once you have written your docs you need a way to collect all of it into a single place, typically a web site.  The most common way to do this in python is to use the [Sphinx](https://www.sphinx-doc.org/en/master/index.html) package.  The setup for Sphinx can be a bit involved, but once set up it "just works."
@@ -39,29 +39,34 @@ Once you have written your docs you need a way to collect all of it into a singl
 Sphinx has already been set up on this project, but while I was doing it I took notes about every step.  To setup Sphinx on this project I used the following commands:
 
 ```bash
+# install sphinx and a few add-ons into the env
 pip install sphinx, myst-nb, sphinx_rtd_theme
 
+# navigate into the repository
 cd DISCnet_workshop
+# make a new folder to hold the documentation
 mkdir docs
 cd docs
+# set up sphinx
 sphinx-quickstart
 ```
 
-with the following options:
+I used the following quickstart options:
 - Separate source and build directories (y/n) [n]: y
 - Project name: Data Transforms
 - Author name(s): Coleman Krawczyk
 - Project release []: 0.1.0
 - Project language [en]: en
 
-The final part the setup is adjusting the `docs/source/conf.py` file to tell it where our source package lives:
+The final part the setup is adjusting the `docs/source/conf.py` file to:
+1. tell it where our source package lives:
 ```python
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../..'))
 ```
 
-Tell Sphinx what extensions to use:
+2. Tell Sphinx what extensions to use:
 ```python
 extensions = [
     'sphinx.ext.autodoc',  # auto find doc strings in source code
@@ -85,7 +90,7 @@ exclude_patterns = [
 ]
 ```
 
-And change the theme:
+3. And change the theme:
 ```python
 html_theme = 'sphinx_rtd_theme'
 ```
@@ -124,6 +129,7 @@ DISCnet Workshop: Writing Code as a Team
    :caption: Setting the Stage
 
    introduction
+   schedule
    the_task
 
 .. toctree::

--- a/docs/source/writing_documentation.md
+++ b/docs/source/writing_documentation.md
@@ -181,3 +181,8 @@ make clean
 make html
 cd ..
 ```
+
+## Tutorial Driven Development
+It is quite common in fast moving projects for the documentation and tutorials to become out of date with the code.  To try and combat this it can be helpful to adapt to a tutorial driven workflow.  In this kind of workflow you sit down and write the full tutorial **first** and only once it is finished do you updated the code to match the new tutorial.  This ensure that the tutorial always matches the current code and helps you keep in mind how the code is intended to be used.
+
+This method works best when you can involve some of the people who will be using your code in the process of making the tutorials.  You can get rapid feedback about the user experience and use that to better inform you about the best way to structure the code.  These tutorials can also inform you of various test cases you can create for your code and works well with test driven development as well (more on this in the next section).


### PR DESCRIPTION
Dependabot now works with pyproject.toml files using `flit`!  I have removed the warning that talks about this not working.

Also added a small clarification about `requirements.txt`/lock files.